### PR TITLE
Set up blog post and demo component system

### DIFF
--- a/config/collections.js
+++ b/config/collections.js
@@ -9,6 +9,7 @@ export default function setupCollections(eleventyConfig) {
     const result = collectionApi.getFilteredByGlob([
       "src/posts/**/*.md",
       "src/posts/**/*.mdx",
+      "src/posts/**/index.webc",
     ]);
     result.sort((a, b) => b.date - a.date);
     return result;

--- a/config/extensions/mdx.js
+++ b/config/extensions/mdx.js
@@ -2,15 +2,19 @@ import { compile } from "@mdx-js/mdx";
 import path from "node:path";
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
-import rehypePrism from "rehype-prism-plus";
 import remarkGfm from "remark-gfm";
 import { renderToStaticMarkup } from "react-dom/server";
 import * as runtime from "react/jsx-runtime";
 import { jsx } from "react/jsx-runtime";
 import { register } from "node:module";
+import rehypeShiki from "@shikijs/rehype";
+import { getHighlighter } from "../highlighter.js";
+
+const highlighter = await getHighlighter();
+const rehypeShikiPlugin = [rehypeShiki, { highlighter, theme: "github-dark" }];
 
 register("@mdx-js/node-loader", import.meta.url, {
-  rehypePlugins: [rehypePrism],
+  rehypePlugins: [rehypeShikiPlugin],
 });
 
 export default function setupMdxExtension(eleventyConfig) {
@@ -18,30 +22,23 @@ export default function setupMdxExtension(eleventyConfig) {
     key: "11ty.js",
     async compile(_, inputPath) {
       const file = await fs.promises.readFile(inputPath, "utf8");
-
       const absolutePath = path.resolve(inputPath);
-
       const compiled = await compile(file, {
         outputFormat: "function-body",
         useDynamicImport: true,
         remarkPlugins: [remarkGfm],
-        rehypePlugins: [rehypePrism],
+        rehypePlugins: [rehypeShikiPlugin],
         baseUrl: pathToFileURL(absolutePath),
-        //baseUrl: new URL(inputPath, "file://"),
       });
-
       const createModule = new Function(
         "React",
         `return (async () => { ${compiled.value} })()`,
       );
-
-      const { default: Content } = await createModule(runtime); // ✅ Evaluate the wrapped async module
-
+      const { default: Content } = await createModule(runtime);
       return async function () {
         return renderToStaticMarkup(jsx(Content, {}));
       };
     },
   });
-
   eleventyConfig.addTemplateFormats("mdx");
 }

--- a/config/highlighter.js
+++ b/config/highlighter.js
@@ -1,0 +1,13 @@
+import { createHighlighter } from "shiki";
+
+let highlighter;
+
+export async function getHighlighter() {
+  if (!highlighter) {
+    highlighter = await createHighlighter({
+      themes: ["github-dark"],
+      langs: ["javascript", "typescript", "html", "css", "bash", "json", "typ"],
+    });
+  }
+  return highlighter;
+}

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,34 +1,41 @@
-import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
+import { createHighlighter } from "shiki";
+import { fromHighlighter } from "@shikijs/markdown-it";
 import pluginWebc from "@11ty/eleventy-plugin-webc";
 import { RenderPlugin } from "@11ty/eleventy";
 import markdownIt from "markdown-it";
+import { getHighlighter } from "./highlighter.js";
 
-export default function setupPlugins(eleventyConfig) {
+export default async function setupPlugins(eleventyConfig) {
+  const highlighter = await getHighlighter();
 
+  const md = markdownIt({ html: true });
 
-  const md = markdownIt();
+  md.use(fromHighlighter(highlighter, { theme: "github-dark" }));
 
   const defaultFence = md.renderer.rules.fence.bind(md.renderer);
-
   md.renderer.rules.fence = (tokens, idx, options, env, self) => {
     const token = tokens[idx];
     const lang = token.info.trim().split(/\s+/)[0] || "code";
     const inner = defaultFence(tokens, idx, options, env, self);
     return `<div class="code-block">
-  <div class="code-block__header">
-    <span class="code-block__lang">${lang}</span>
+  <div class="code-block__header cluster repel">
+<span aria-hidden="true">&lt;/&gt;</span>
+    <dl>
+      <dt class="visually-hidden">Code language</dt>
+      <dd>${lang}</dd>
+    </dl>
   </div>
   ${inner}
 </div>`;
   };
 
-  eleventyConfig.addPlugin(syntaxHighlight, { markdownItOptions: { highlight: null } });
   eleventyConfig.setLibrary("md", md);
-
-
-
   eleventyConfig.addPlugin(pluginWebc, {
-    components: "src/_components/**/*.webc",
+    components: [
+      "src/_components/**/*.webc",
+      "src/posts/**/_demos/*.webc",
+    ],
   });
   eleventyConfig.addPlugin(RenderPlugin);
 }
+

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,9 +1,32 @@
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
 import pluginWebc from "@11ty/eleventy-plugin-webc";
 import { RenderPlugin } from "@11ty/eleventy";
+import markdownIt from "markdown-it";
 
 export default function setupPlugins(eleventyConfig) {
-  eleventyConfig.addPlugin(syntaxHighlight);
+
+
+  const md = markdownIt();
+
+  const defaultFence = md.renderer.rules.fence.bind(md.renderer);
+
+  md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+    const token = tokens[idx];
+    const lang = token.info.trim().split(/\s+/)[0] || "code";
+    const inner = defaultFence(tokens, idx, options, env, self);
+    return `<div class="code-block">
+  <div class="code-block__header">
+    <span class="code-block__lang">${lang}</span>
+  </div>
+  ${inner}
+</div>`;
+  };
+
+  eleventyConfig.addPlugin(syntaxHighlight, { markdownItOptions: { highlight: null } });
+  eleventyConfig.setLibrary("md", md);
+
+
+
   eleventyConfig.addPlugin(pluginWebc, {
     components: "src/_components/**/*.webc",
   });

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -9,6 +9,8 @@ import setupMdxExtension from "./config/extensions/mdx.js";
 import setupJsxExtension from "./config/extensions/jsx.js";
 
 export default function (eleventyConfig) {
+  const isDevelopment = process.env.ELEVENTY_ENV === "development";
+
   setupPlugins(eleventyConfig);
   setupCollections(eleventyConfig);
   setupShortcodes(eleventyConfig);
@@ -16,6 +18,14 @@ export default function (eleventyConfig) {
   setupFilters(eleventyConfig);
   setupMdxExtension(eleventyConfig);
   setupJsxExtension(eleventyConfig);
+
+  eleventyConfig.ignores.add("src/posts/**/_demos/**");
+  eleventyConfig.ignores.add("**/posts/**/_demos/**");
+
+  if (!isDevelopment) {
+    eleventyConfig.ignores.add("src/posts/_tests/**");
+    eleventyConfig.ignores.add("**/posts/_tests/**");
+  }
 
   eleventyConfig.addPassthroughCopy("./src/assets/**/*.svg");
   eleventyConfig.addPassthroughCopy({
@@ -30,13 +40,5 @@ export default function (eleventyConfig) {
       output: "dist",
       includes: "_includes",
     },
-    defaults: [
-      {
-        directory: "posts",
-        data: {
-          layout: "post.webc",
-        },
-      },
-    ],
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@11ty/eleventy-plugin-webc": "^0.11.2",
         "autoprefixer": "^10.4.21",
         "cssnano": "^7.0.6",
+        "esbuild": "^0.27.3",
         "postcss": "^8.5.3",
         "postcss-cli": "^11.0.1",
         "postcss-import": "^16.1.0",
@@ -1427,7 +1428,6 @@
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "@mdx-js/node-loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
+        "@shikijs/markdown-it": "^4.0.2",
+        "@shikijs/rehype": "^4.0.2",
         "esbuild-register": "^3.6.0",
         "prism-react-renderer": "^2.4.1",
-        "prismjs": "^1.30.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "rehype-prism-plus": "^2.0.1",
         "remark-gfm": "^4.0.1",
+        "shiki": "^4.0.2",
         "tsx": "^4.19.3"
       },
       "devDependencies": {
@@ -152,19 +152,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/11ty"
-      }
-    },
-    "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.2.tgz",
-      "integrity": "sha512-T6xVVRDJuHlrFMHbUiZkHjj5o1IlLzZW+1IL9eUsyXFU7rY2ztcYhZew/64vmceFFpQwzuSfxQOXxTJYmKkQ+A==",
-      "license": "MIT",
-      "dependencies": {
-        "prismjs": "^1.30.0"
       },
       "funding": {
         "type": "opencollective",
@@ -866,6 +853,144 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/markdown-it": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/markdown-it/-/markdown-it-4.0.2.tgz",
+      "integrity": "sha512-7DDEhknj/mXTN7ME8CjKWBv5O/4YgOiJBZLgs/NbUFMC7Ik1x/VEhaK+aBjX60bJdok0E2mxEYan/GzJ2xRx+A==",
+      "license": "MIT",
+      "dependencies": {
+        "markdown-it": "^14.1.1",
+        "shiki": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "markdown-it-async": "^2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-async": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/rehype": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-4.0.2.tgz",
+      "integrity": "sha512-cmPlKLD8JeojasNFoY64162ScpEdEdQUMuVodPCrv1nx1z3bjmGwoKWDruQWa/ejSznImlaeB0Ty6Q3zPaVQAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.1",
+        "shiki": "4.0.2",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/slugify": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
@@ -1088,7 +1213,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-differ": {
@@ -2011,6 +2135,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2570,57 +2695,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-estree": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
@@ -2643,6 +2717,29 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2702,21 +2799,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
       "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
-      },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/htmlparser2": {
@@ -3024,7 +3114,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -3108,7 +3197,6 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
@@ -3126,7 +3214,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -3459,7 +3546,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -4419,6 +4505,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -4444,12 +4547,6 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
-    "node_modules/parse-numeric-range": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
-      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
-      "license": "ISC"
-    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -4461,6 +4558,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -5253,15 +5351,6 @@
         "react": ">=16.0.0"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -5283,7 +5372,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5445,50 +5533,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/refractor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
-      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
       "license": "MIT",
       "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/prismjs": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "parse-entities": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
+        "regex-utilities": "^2.3.0"
       }
     },
-    "node_modules/rehype-parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
       "license": "MIT",
       "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
+        "regex-utilities": "^2.3.0"
       }
     },
-    "node_modules/rehype-prism-plus": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.2.tgz",
-      "integrity": "sha512-jTHb8ZtQHd2VWAAKeCINgv/8zNEF0+LesmwJak69GemoPVN9/8fGEARTvqOpKqmN57HwaM9z8UKBVNVJe8zggw==",
-      "license": "MIT",
-      "dependencies": {
-        "hast-util-to-string": "^3.0.1",
-        "parse-numeric-range": "^1.3.0",
-        "refractor": "^5.0.0",
-        "rehype-parse": "^9.0.1",
-        "unist-util-filter": "^5.0.1",
-        "unist-util-visit": "^5.1.0"
-      }
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/rehype-recma": {
       "version": "1.0.0",
@@ -5743,6 +5810,25 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -6087,7 +6173,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -6107,17 +6192,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-filter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
-      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
       }
     },
     "node_modules/unist-util-is": {
@@ -6280,20 +6354,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -6354,16 +6414,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "build:demos": "node scripts/build-demos.js",
+    "build": "npm run build:demos && eleventy && npm run build:css",
     "build:css": "postcss src/assets/css/main.css -o dist/assets/css/main.css",
     "watch:css": "npm run build:css -- --watch",
-    "build": "eleventy && npm run build:css",
     "start": "ELEVENTY_ENV=development eleventy --serve & npm run watch:css"
   },
   "keywords": [],
@@ -18,6 +19,7 @@
     "@11ty/eleventy-plugin-webc": "^0.11.2",
     "autoprefixer": "^10.4.21",
     "cssnano": "^7.0.6",
+    "esbuild": "^0.27.3",
     "postcss": "^8.5.3",
     "postcss-cli": "^11.0.1",
     "postcss-import": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
     "postcss-import-ext-glob": "^2.1.1"
   },
   "dependencies": {
-    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "@mdx-js/node-loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
+    "@shikijs/markdown-it": "^4.0.2",
+    "@shikijs/rehype": "^4.0.2",
     "esbuild-register": "^3.6.0",
     "prism-react-renderer": "^2.4.1",
-    "prismjs": "^1.30.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "rehype-prism-plus": "^2.0.1",
     "remark-gfm": "^4.0.1",
+    "shiki": "^4.0.2",
     "tsx": "^4.19.3"
   }
 }

--- a/scripts/build-demos.js
+++ b/scripts/build-demos.js
@@ -1,4 +1,3 @@
-// scripts/build-demos.js
 import esbuild from "esbuild";
 import { glob } from "fs/promises";
 

--- a/scripts/build-demos.js
+++ b/scripts/build-demos.js
@@ -1,0 +1,19 @@
+// scripts/build-demos.js
+import esbuild from "esbuild";
+import { glob } from "fs/promises";
+
+const demos = await Array.fromAsync(glob("src/_demos/**/*.jsx"));
+
+if (demos.length === 0) {
+  console.log("No demos found, skipping.");
+} else {
+  await esbuild.build({
+    entryPoints: demos,
+    bundle: true,
+    outdir: "dist/demos",
+    format: "esm",
+    jsx: "automatic",
+    external: ["react", "react-dom"],
+  });
+  console.log(`Built ${demos.length} demo(s).`);
+}

--- a/scripts/scaffold-demo-post.js
+++ b/scripts/scaffold-demo-post.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.join(__dirname, "..");
+
+if (process.argv.length < 4) {
+	console.error("Usage: node scripts/scaffold-demo-post.js <slug> <title>");
+	console.error("Example: node scripts/scaffold-demo-post.js my-component 'My Component  Demo'");
+	process.exit(1);
+}
+
+const slug = process.argv[2];
+const title = process.argv[3];
+const today = new Date().toISOString().split("T")[0];
+const postFolder = `${today}-${slug}`;
+const postPath = path.join(projectRoot, "src/posts", postFolder);
+const demosPath = path.join(postPath, "_demos");
+
+try {
+	await fs.mkdir(demosPath, { recursive: true });
+	console.log(`Created ${postPath}`);
+	console.log(`Created ${demosPath}`);
+
+	const demoFileName = `demo-${slug}.webc`;
+	const indexContent = `---
+title: ${title}
+mainTitle: ${title}
+---
+
+Your demo content here.
+
+<demo-embed name="demo-1">
+	<demo-${slug}></demo-${slug}>
+</demo-embed>
+`;
+	await fs.writeFile(path.join(postPath, "index.webc"), indexContent);
+	console.log(`Created index.webc`);
+
+	const demoContent = `<div class="demo" webc:root="override">
+	<p>Demo content here</p>
+</div>
+
+<style webc:scoped>
+	:host {
+		padding: 1rem;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+	}
+</style>
+`;
+	await fs.writeFile(path.join(demosPath, demoFileName), demoContent);
+	console.log(`Created _demos/${demoFileName}`);
+
+	console.log(`\nPost demo scaffold created at: src/posts/${postFolder}/`);
+	console.log(`\nNext steps:`);
+	console.log(`1. Edit src/posts/${postFolder}/index.webc`);
+	console.log(`2. Edit src/posts/${postFolder}/_demos/${demoFileName}`);
+} catch (error) {
+	console.error("Error creating post scaffold:", error.message);
+	process.exit(1);
+}

--- a/src/_components/demo-embed.webc
+++ b/src/_components/demo-embed.webc
@@ -1,20 +1,22 @@
-<div webc:root="override">
-	<div class="title">Website title</div>
-	<div class="subtitle">This website is about...</div>
+<div class="demo-block" webc:root="override">
+	<div class="demo-block__header cluster repel">
+		<span aria-hidden="true">&lt;/&gt;</span>
+		<dl>
+			<dt class="visually-hidden">Demo</dt>
+			<dd @text="name"></dd>
+		</dl>
+	</div>
+	<div class="demo-block__content">
+		<slot></slot>
+	</div>
 </div>
 
 <style webc:scoped>
-	:host {
-		border: 1px solid black;
-		font-family: Arial;
+	.demo-block {
+		display: block;
+		border: 1px solid;
+	}
+	.demo-block__content {
 		padding: var(--space-m);
-	}
-
-	:host .title {
-		font-size: var(--step-3);
-	}
-
-	:host .subtitle {
-		font-size: var(--step-1);
 	}
 </style>

--- a/src/_demos/button-counter.jsx
+++ b/src/_demos/button-counter.jsx
@@ -1,0 +1,16 @@
+// src/_demos/button-counter.jsx
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+function ButtonCounter() {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>+1</button>
+    </div>
+  );
+}
+
+const container = document.getElementById("demo-button-counter");
+createRoot(container).render(<ButtonCounter />);

--- a/src/_includes/post.webc
+++ b/src/_includes/post.webc
@@ -5,8 +5,8 @@ layout: layout.webc
 <hero :title="title" :subtitle="subTitle"></hero>
 
 <div class="grid">
-  <div class="grid__cell"></div>
-  <div class="grid__cell main">
-    <div class="grid__content flow text" @raw="content"></div>
-  </div>
+	<div class="grid__cell"></div>
+	<div class="grid__cell main">
+		<div class="grid__content flow text" @html="content"></div>
+	</div>
 </div>

--- a/src/assets/css/_code-block.css
+++ b/src/assets/css/_code-block.css
@@ -1,0 +1,19 @@
+/* for inline code tag */
+code {
+	background: var(--color-black);
+	color: white;
+	padding: 0 var(--space-3xs);
+}
+
+.code-block {
+	border: 1px solid;
+}
+
+.code-block__header {
+	padding: var(--space-3xs) var(--space-m);
+}
+
+.code-block pre {
+	border-radius: 0;
+	margin: 0;
+}

--- a/src/assets/css/_code-block.css
+++ b/src/assets/css/_code-block.css
@@ -1,19 +1,28 @@
 /* for inline code tag */
-code {
-	background: var(--color-black);
-	color: white;
-	padding: 0 var(--space-3xs);
+
+:not(pre)>code {
+  background: var(--color-black);
+  color: white;
+  padding: 0 var(--space-3xs);
 }
 
 .code-block {
-	border: 1px solid;
+  border: 1px solid;
 }
 
 .code-block__header {
-	padding: var(--space-3xs) var(--space-m);
+  font-family: monospace;
+  padding: var(--space-3xs) var(--space-m);
 }
 
 .code-block pre {
-	border-radius: 0;
-	margin: 0;
+  border-radius: 0;
+  line-height: 1.2;
+  margin: 0;
+  padding: var(--space-m);
+  tab-size: 4;
+}
+
+.code-block dd {
+  margin-inline-start: 0;
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,4 +1,3 @@
-@import "prismjs/themes/prism-okaidia.css";
 @import "_reset.css";
 @import "_variables.css";
 @import "_grid.css";
@@ -10,6 +9,7 @@
   margin-block: 0;
 }
 
+
 body {
   background-color: var(--color-yellow);
   color: var(--color-black);
@@ -19,10 +19,12 @@ body {
   font-size: var(--step-0);
 }
 
+
 a:hover {
   background-color: var(--color-black);
   color: var(--color-yellow);
 }
+
 
 .wrapper {
   margin-left: auto;
@@ -107,7 +109,7 @@ svg {
   align-content: center;
 }
 
-.flow > * + * {
+.flow>*+* {
   margin-top: var(--flow-space, 1rem);
 }
 
@@ -128,4 +130,16 @@ svg {
 
 .italic {
   font-style: italic;
+}
+
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 0;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -4,6 +4,7 @@
 @import "_grid.css";
 @import "_nav.css";
 @import "_hero.css";
+@import "_code-block.css";
 
 :where(body, h1, h2, h3, h4, p, figure, blockquote, dl, dd) {
   margin-block: 0;

--- a/src/posts/2026-03-07-test.md
+++ b/src/posts/2026-03-07-test.md
@@ -1,0 +1,29 @@
+---
+title: test
+mainTitle: test
+---
+
+bla bla
+
+```typ
+#set text(font: "Linux Libertine", size: 11pt)
+```
+
+```js
+const x = 1;
+```
+
+blablabla
+
+`bla`
+
+
+
+
+
+```css
+ul {
+	padding-inline-start: 1lh;
+}
+```
+

--- a/src/posts/_tests/2026-03-07-test.md
+++ b/src/posts/_tests/2026-03-07-test.md
@@ -1,6 +1,7 @@
 ---
-title: test
-mainTitle: test
+title: TEST - markdown code snippets
+mainTitle: TEST - markdown code snippets 
+teaser: Test code snippets inside of a markdown file
 ---
 
 bla bla

--- a/src/posts/_tests/2026-03-19-demo-test/_demos/my-demo.webc
+++ b/src/posts/_tests/2026-03-19-demo-test/_demos/my-demo.webc
@@ -1,0 +1,11 @@
+<div class="demo" webc:root="override">
+	<p>Demo content here</p>
+</div>
+
+<style webc:scoped>
+	:host {
+		padding: 1rem;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+	}
+</style>

--- a/src/posts/_tests/2026-03-19-demo-test/index.webc
+++ b/src/posts/_tests/2026-03-19-demo-test/index.webc
@@ -1,0 +1,22 @@
+---
+title: TEST - demo test
+mainTitle: TEST - demo test
+teaser: Test demo-embed in webc blog post. This test fails at the moment
+---
+
+# this is markdown
+
+- bullet 1
+- bullet 2
+- bullet 3
+
+test demo
+
+<demo-embed name="demo-1">
+	<my-demo></my-demo>
+</demo-embed>
+
+
+```js
+let x = 12;
+```

--- a/src/posts/_tests/2026-03-20-button-showcase/_demos/demo-button-showcase.webc
+++ b/src/posts/_tests/2026-03-20-button-showcase/_demos/demo-button-showcase.webc
@@ -1,0 +1,83 @@
+<div class="demo" webc:root="override">
+	<div class="button-row" role="group" aria-label="Button variants">
+		<button class="btn btn--primary" type="button">Primary</button>
+		<button class="btn btn--secondary" type="button">Secondary</button>
+		<button class="btn btn--ghost" type="button">Ghost</button>
+		<button class="btn btn--danger" type="button">Danger</button>
+		<button class="btn btn--primary" type="button" disabled>
+			Disabled
+		</button>
+	</div>
+</div>
+
+<style webc:scoped>
+	:host {
+		padding: var(--space-s);
+		border: 1px solid #ddd;
+		border-radius: 4px;
+	}
+
+	.button-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2xs);
+	}
+
+	.btn {
+		appearance: none;
+		border: 1px solid var(--color-black);
+		border-radius: 999px;
+		background: var(--color-black);
+		color: white;
+		font-size: var(--step--1);
+		line-height: 1.1;
+		padding: 0.6rem 1rem;
+		cursor: pointer;
+		transition:
+			transform 120ms ease,
+			box-shadow 120ms ease,
+			background-color 120ms ease,
+			color 120ms ease;
+	}
+
+	.btn:hover:not(:disabled) {
+		transform: translateY(-1px);
+		box-shadow: 0 2px 0 0 var(--color-black);
+	}
+
+	.btn:active:not(:disabled) {
+		transform: translateY(0);
+		box-shadow: none;
+	}
+
+	.btn:focus-visible {
+		outline: 2px solid var(--color-black);
+		outline-offset: 2px;
+	}
+
+	.btn--primary {
+		background: var(--color-black);
+		color: white;
+	}
+
+	.btn--secondary {
+		background: var(--color-yellow);
+		color: var(--color-black);
+	}
+
+	.btn--ghost {
+		background: transparent;
+		color: var(--color-black);
+	}
+
+	.btn--danger {
+		background: #c1121f;
+		border-color: #c1121f;
+		color: white;
+	}
+
+	.btn:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+</style>

--- a/src/posts/_tests/2026-03-20-button-showcase/index.webc
+++ b/src/posts/_tests/2026-03-20-button-showcase/index.webc
@@ -1,0 +1,15 @@
+---
+title: TEST - Button Showcase
+mainTitle: TEST - Button Showcase
+teaser: Test demo embed inside webc directory-based post
+---
+
+Before the demo embed
+
+<demo-embed name="demo-1">
+	<demo-button-showcase></demo-button-showcase>
+</demo-embed>
+
+After the demo embed
+
+## At the moment, markdown doesn't work

--- a/src/posts/_tests/markdown-demo-test.md
+++ b/src/posts/_tests/markdown-demo-test.md
@@ -1,0 +1,26 @@
+---
+title: TEST - Markdown Demo Test
+mainTitle: TEST - Markdown Demo Test
+teaser: Test markdown + demo embed in post .md
+---
+
+# Markdown heading
+
+- item one
+- item two
+
+Text before the demo.
+
+## test heading before demo
+
+{% renderTemplate "webc" %}
+
+<demo-embed name="demo-md-1">
+<my-demo></my-demo>
+</demo-embed>
+
+{% endrenderTemplate %}
+
+```js
+const value = 42;
+```

--- a/src/posts/_tests/markdown-directory-demo/_demos/demo-markdown-directory.webc
+++ b/src/posts/_tests/markdown-directory-demo/_demos/demo-markdown-directory.webc
@@ -1,0 +1,11 @@
+<div class="demo" webc:root="override">
+	<p>Demo inside a directory-based markdown post.</p>
+</div>
+
+<style webc:scoped>
+	:host {
+		padding: 1rem;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+	}
+</style>

--- a/src/posts/_tests/markdown-directory-demo/index.md
+++ b/src/posts/_tests/markdown-directory-demo/index.md
@@ -1,0 +1,26 @@
+---
+title: TEST - Markdown Directory Demo
+mainTitle: TEST - Markdown Directory Demo
+slug: markdown-directory-demo
+teaser: Test markdown + demo WebC in a directory-based post.
+---
+
+# Markdown works here
+
+- first item
+- second item
+
+Text before the embedded demo.
+
+{% renderTemplate "webc" %}
+<demo-embed name="demo-md-dir-1">
+<demo-markdown-directory></demo-markdown-directory>
+</demo-embed>
+{% endrenderTemplate %}
+
+Text after embedded demo
+
+
+```js
+const answer = 42;
+```

--- a/src/posts/posts.11tydata.js
+++ b/src/posts/posts.11tydata.js
@@ -3,7 +3,6 @@ export default {
   eleventyComputed: {
     permalink: function (data) {
       if (data.permalink) {
-        // First, if I have already specified a permalink, just use it
         return data.permalink;
       } else {
         const slug = data.slug ?? this.slugify(data.title);


### PR DESCRIPTION
Builds the infrastructure for blog posts with embedded interactive demos.

## Changes

**Blog infrastructure**
- Fix post collection to include WebC entry files (`index.webc`)
- Restore post layout chain (`post.webc` -> `layout.webc`)
- Enable HTML passthrough in markdown-it for `renderTemplate` blocks
- Add Shiki syntax highlighting with custom code block styling

**Demo system**
- Register demo components automatically via glob (`src/posts/**/_demos/*.webc`)
- Add `demo-embed` wrapper component with labeled header and scoped styles
- Ignore `_demos/` directories so components don't become pages
- Scaffold script for generating new demo posts (`scripts/scaffold-demo-post.js`)

**Test posts**
- Add reference implementations in `src/posts/_tests/` covering:
  - WebC post with demo component
  - WebC post with component variant showcase
  - Markdown single-file post with embedded demo
  - Markdown directory-based post with separate demo component
- Test posts excluded from production builds (`ELEVENTY_ENV !== "development"`)