### PR TITLE
Update GitHub Pages actions to version compatible with Node 24

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -28,7 +28,7 @@ jobs:
               run: npm run build
 
             - name: Upload artifacts
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v4
               with:
                   path: ./dist
 
@@ -42,4 +42,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@v5


### PR DESCRIPTION
Keep the Pages deployment workflow compatible with GitHub Actions runtime defaults (Node 24).

## Changes

- Upgraded Pages workflow actions to remove Node 20 deprecation risk:
  - actions/upload-pages-artifact from v3 to v4
  - actions/deploy-pages from v4 to v5
